### PR TITLE
Add developement docker-compose with postgres and reporter svcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.env.dev
+.env.prod
 
 # Spyder project settings
 .spyderproject

--- a/backend/main/Dockerfile
+++ b/backend/main/Dockerfile
@@ -1,0 +1,21 @@
+# pull official base image
+FROM python:3.9.6-alpine
+
+# set work directory
+WORKDIR /usr/src/app
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install psycopg2 dependencies
+RUN apk update \
+    && apk add postgresql-dev gcc python3-dev musl-dev
+
+# install dependencies
+RUN pip install --upgrade pip
+COPY ./requirements.txt .
+RUN pip install -r requirements.txt
+
+# copy project
+COPY . .

--- a/backend/main/reporter/settings.py
+++ b/backend/main/reporter/settings.py
@@ -21,12 +21,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-*g2)v*anxlva1$qr01@om2d4h8714&#ewn%ot($qevj3_8%691"
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = int(os.getenv("DEBUG", default=0))
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS").split(" ")
 
 
 # Application definition
@@ -83,11 +83,11 @@ WSGI_APPLICATION = "reporter.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": os.getenv("DB_NAME"),
-        "USER": os.getenv("DB_USER"),
-        "PASSWORD": os.getenv("DB_PASSWORD"),
+        "NAME": os.getenv("POSTGRES_DB"),
+        "USER": os.getenv("POSTGRES_USER"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
         "HOST": os.getenv("DB_HOST"),
-        "PORT": os.getenv("DB_PORT"),
+        "PORT": "",
     }
 }
 
@@ -135,10 +135,5 @@ STATIC_URL = "/static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:8080",
-]
+CORS_ALLOWED_ORIGINS = ["http://"+i for i in ALLOWED_HOSTS]
 
-CUSTOM_HOSTNAME = os.getenv("HOSTNAME")
-if CUSTOM_HOSTNAME != None:
-    CORS_ALLOWED_ORIGINS.append("http://{}".format(CUSTOM_HOSTNAME))

--- a/backend/main/requirements.txt
+++ b/backend/main/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==2.0.11
 coreapi==2.3.3
 coreschema==0.0.4
 Django==3.2.12
+django-cors-headers==3.11.0
 djangorestframework==3.13.1
 drf-yasg==1.20.0
 idna==3.3
@@ -12,7 +13,7 @@ itypes==1.2.0
 Jinja2==3.0.3
 MarkupSafe==2.0.1
 packaging==21.3
-pkg-resources==0.0.0
+psycopg2==2.9.3
 pyparsing==3.0.7
 pytz==2021.3
 requests==2.27.1

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  reporter:
+    build: ./backend/main/
+    command: 
+      sh -c " python manage.py migrate &&
+              python manage.py runserver 0.0.0.0:8000"
+    volumes:
+      - ./backend/main/:/usr/src/app/
+    ports:
+      - 8000:8000
+    env_file:
+      - ./.env.dev
+    depends_on:
+      - db
+  db:
+    image: postgres:13.0-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    env_file:
+      - ./.env.dev
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
### Considerations
1. `http://` schema is hard-coded and there is currently no support for `HTTPS`
2. Migrations are always checked (don't know if it is the best practice and will check it later) 
3. No web-server is used (will be added with production docker-compose file)